### PR TITLE
Add Load & Release methods to DynamicEngine

### DIFF
--- a/include/libcryptosec/DynamicEngine.h
+++ b/include/libcryptosec/DynamicEngine.h
@@ -59,6 +59,20 @@ public:
 	 * @see Engine::removeFromEnginesList().
 	 */
 	void removeFromEnginesList() throw (EngineException);
+	
+	/**
+	 * Carrega a Engine e seus algoritmos.
+	 * @throw EngineException caso a Engine esteja indisponível ou ocorra erro ao carregá-la.
+	 * @return True se a Engine foi carregada com sucesso, senão False
+	 */
+	bool load() throw (EngineException);
+	
+	/**
+	 * Libera a Engine e seus algoritmos.
+	 * @throw EngineException caso a Engine esteja indisponível.
+	 * @return True se a Engine foi liberada com sucesso, senão False
+	 */
+	bool release() throw (EngineException);
 };
 
 #endif /*DYNAMICENGINE_H_*/

--- a/src/DynamicEngine.cpp
+++ b/src/DynamicEngine.cpp
@@ -102,3 +102,18 @@ void DynamicEngine::removeFromEnginesList() throw (EngineException)
 		throw EngineException(EngineException::REMOVE_ENGINE_FROM_LIST, "DynamicEngine::removeFromEnginesList");
 	}
 }
+
+bool DynamicEngine::load() throw (EngineException)
+{
+	int rc = ENGINE_init(this->engine);
+	rc &= ENGINE_set_default(this->engine, ENGINE_METHOD_ALL);
+	OpenSSL_add_all_algorithms();
+	return rc;
+}
+
+bool DynamicEngine::release() throw (EngineException)
+{
+	int rc = ENGINE_finish(this->engine);
+	rc &= ENGINE_free(this->engine);
+	return rc;
+}


### PR DESCRIPTION
Add load and release control methods to load/release engines on demand, such that if the execution of a code block has to be done using a specific engine you only need to surround said block with these methods. 