### PR TITLE
Fix creation of empty sequence on CertificatePolicies Extension

### DIFF
--- a/src/certificate/PolicyInformation.cpp
+++ b/src/certificate/PolicyInformation.cpp
@@ -80,4 +80,6 @@ POLICYINFO* PolicyInformation::getPolicyInfo() const
 			sk_POLICYQUALINFO_push(ret->qualifiers, policyQualInfo);
 		}
 	}
+
+	return ret;
 }

--- a/src/certificate/PolicyInformation.cpp
+++ b/src/certificate/PolicyInformation.cpp
@@ -71,11 +71,13 @@ POLICYINFO* PolicyInformation::getPolicyInfo() const
 	POLICYQUALINFO *policyQualInfo;
 	ret = POLICYINFO_new();
 	ret->policyid = OBJ_dup(this->policyIdentifier.getObjectIdentifier());
-	ret->qualifiers = sk_POLICYQUALINFO_new_null();
-	for (i=0;i<this->policyQualifiers.size();i++)
-	{
-		policyQualInfo = this->policyQualifiers.at(i).getPolicyQualInfo();
-		sk_POLICYQUALINFO_push(ret->qualifiers, policyQualInfo);
+
+	if (this->policyQualifiers.size()) {
+		ret->qualifiers = sk_POLICYQUALINFO_new_null();
+		for (i=0;i<this->policyQualifiers.size();i++)
+		{
+			policyQualInfo = this->policyQualifiers.at(i).getPolicyQualInfo();
+			sk_POLICYQUALINFO_push(ret->qualifiers, policyQualInfo);
+		}
 	}
-	return ret;
 }

--- a/src/certificate/PolicyInformation.cpp
+++ b/src/certificate/PolicyInformation.cpp
@@ -72,7 +72,8 @@ POLICYINFO* PolicyInformation::getPolicyInfo() const
 	ret = POLICYINFO_new();
 	ret->policyid = OBJ_dup(this->policyIdentifier.getObjectIdentifier());
 
-	if (this->policyQualifiers.size()) {
+	if (this->policyQualifiers.size())
+	{
 		ret->qualifiers = sk_POLICYQUALINFO_new_null();
 		for (i=0;i<this->policyQualifiers.size();i++)
 		{


### PR DESCRIPTION
Currently, when creating a Certificate which has the Certificate Policies extension but the included policy has no Policy Qualifier, the certificate is issued with an empty qualifiers sequence. According to [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.4) the policyQualifiers is an optional field, however if it exists it must be greater than zero, and thus the empty sequence would make the Certificate format invalid.

```   
   PolicyInformation ::= SEQUENCE {
        policyIdentifier   CertPolicyId,
        policyQualifiers   SEQUENCE SIZE (1..MAX) OF
                                PolicyQualifierInfo OPTIONAL } 
```

To fix this, before creating the policyQualifiers sequence, first it checks if said Policy has any qualifiers and only creates the sequence if it does.