### PR TITLE
Add new PKCS12 error code handling

### DIFF
--- a/include/libcryptosec/exception/Pkcs12Exception.h
+++ b/include/libcryptosec/exception/Pkcs12Exception.h
@@ -15,6 +15,7 @@ public:
 		KEY_AND_CERT_DO_NOT_MATCH,
 		PARSE_ERROR,
 		MAC_VERIFY_FAILURE,
+		ASN1_INVALID_OBJECT_ENCODING,
 	};
 
 	Pkcs12Exception(std::string where)
@@ -73,12 +74,9 @@ public:
     		case Pkcs12Exception::PARSE_ERROR :
     			ret = "Parse error";
     			break;
-    			//    		case Pkcs12Exception:::
-    			//    			ret = "";
-    			//    			break;
-    			//    		case Pkcs12Exception:::
-    			//    			ret = "";
-    			//    			break;    			
+			case Pkcs12Exception::ASN1_INVALID_OBJECT_ENCODING :
+				ret = "ASN1 invalid enconding";
+				break;
     	}
     	return ret;
     }

--- a/src/Pkcs12.cpp
+++ b/src/Pkcs12.cpp
@@ -144,9 +144,11 @@ void Pkcs12::parse(string password) throw(Pkcs12Exception)
 			case PKCS12_R_MAC_VERIFY_FAILURE :
 				throw Pkcs12Exception(Pkcs12Exception::PARSE_ERROR, "Pkcs12::parse");
 				break;
-				
 			case PKCS12_R_PARSE_ERROR :
 				throw Pkcs12Exception(Pkcs12Exception::MAC_VERIFY_FAILURE, "Pkcs12::parse");
+				break;
+			case ASN1_R_INVALID_OBJECT_ENCODING :
+				throw Pkcs12Exception(Pkcs12Exception::ASN1_INVALID_OBJECT_ENCODING, "Pkcs12::parse");
 				break;
 		}
 	}


### PR DESCRIPTION
This handles an error code related to an invalid PKCS12 structure not previously addressed.